### PR TITLE
Leave ENTRYPOINT as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ ENV SOCAT_VERSION=1.7.3.2-r3
 
 RUN apk add --no-cache socat=$SOCAT_VERSION
 
-ENTRYPOINT ["/usr/bin/socat"]
-
-CMD ["-h"]
+CMD ["/usr/bin/socat", "-h"]
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="socat" \


### PR DESCRIPTION
Un-customize the container entrypoint and move invocation of socat to
the default command. This matches the other images being published, and
makes it easier to exec other processes within the container.