### PR TITLE
Update base image to Alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
-ENV SOCAT_VERSION=1.7.3.2-r4
+ENV SOCAT_VERSION=1.7.3.2-r5
 
 RUN apk add --no-cache socat=$SOCAT_VERSION
 
@@ -8,6 +8,6 @@ CMD ["/usr/bin/socat", "-h"]
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="socat" \
-      org.label-schema.version="1.7.3.2-r3" \
+      org.label-schema.version="1.7.3.2-r5" \
       org.label-schema.url="http://www.dest-unreach.org/socat/" \
       org.label-schema.vcs-url="https://github.com/oildex/docker-socat"


### PR DESCRIPTION
Update the base image to extend from alpine:3.9. Also, bump the socat
package to match.